### PR TITLE
Force text content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,6 @@ function nanobeacon (url, data) {
 
   assert.ok(json.length < MAX_SIZE, 'nanobeacon: data should be smaller than ' + MAX_SIZE + ' bytes. Was ' + json.length + ' bytes')
 
-  var blob = new window.Blob([ json ])
+  var blob = new window.Blob([ json ], { type: 'text/plain; charset=UTF-8' })
   return window.navigator.sendBeacon(url, blob)
 }


### PR DESCRIPTION
It seems to me that [Chrome will block](https://github.com/yoshuawuyts/nanobeacon/issues/1) all json sendBeacon's right now. 

This may break a lot, there is probably a nicer way to do it. Please let me know =).