### PR TITLE
check for sendBeacon before trying to send

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,6 @@ function nanobeacon (url, data) {
 
   var blob = new window.Blob([ json ], { type: 'text/plain; charset=UTF-8' })
 
-  if (window.navigator.doNotTrack) return false
+  if (window.navigator.doNotTrack || !window.navigator.sendBeacon) return false
   return window.navigator.sendBeacon(url, blob)
 }


### PR DESCRIPTION
Right now this fails hard in Safari without a polyfill. 

This PR will make sure we can send before sending.
